### PR TITLE
GH actions index with scip-go

### DIFF
--- a/.github/workflows/lsif-go.yml
+++ b/.github/workflows/lsif-go.yml
@@ -5,7 +5,7 @@ on:
 jobs:
   lsif-go:
     runs-on: ubuntu-latest
-    container: sourcegraph/lsif-go:latest
+    container: sourcegraph/scip-go:latest
     steps:
       - uses: actions/checkout@v1
       - name: Generate LSIF data


### PR DESCRIPTION
Replace lsif code intel builds with scip in github actions

[_Created by Sourcegraph batch change `christine/GithubActions-updateSGTest`._](https://demo.sourcegraph.com/users/christine/batch-changes/GithubActions-updateSGTest)